### PR TITLE
Improve assert count assertion

### DIFF
--- a/tests/integration/DatabaseTest.php
+++ b/tests/integration/DatabaseTest.php
@@ -31,6 +31,6 @@ class DatabaseTest extends TestCase
         $result = self::$pdo->query($sql)->fetchAll();
         $expected = 402976;
 
-        $this->assertEquals($expected, count($result));
+        $this->assertCount($expected, $result);
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `assertCount` to assert the `$result` count is same as `$expected` count.